### PR TITLE
fix(components): updated form and toast components

### DIFF
--- a/frontend/src/components/Toast/Toaster.tsx
+++ b/frontend/src/components/Toast/Toaster.tsx
@@ -20,6 +20,7 @@ export function Toaster() {
         description,
         action,
         icon,
+        iconClassname,
         ...props
       }) {
         return (
@@ -27,7 +28,7 @@ export function Toaster() {
             <div className="flex flex-row">
               {icon && (
                 <div className="flex mr-5 pt-0.5">
-                  <Icon name={icon} />
+                  <Icon name={icon} className={iconClassname} />
                 </div>
               )}
               <div className="grid gap-1">

--- a/frontend/src/components/Tooltip.tsx
+++ b/frontend/src/components/Tooltip.tsx
@@ -62,10 +62,10 @@ const Tooltip = ({
 
 export default Tooltip;
 
-export const InfoToolTip = ({ toolTipContent }: TooltipProps) => {
+export const InfoToolTip = ({ toolTipContent, ...props }: TooltipProps) => {
   return (
-    <Tooltip toolTipContent={toolTipContent}>
-      <Icon name="Info" />
+    <Tooltip toolTipContent={toolTipContent} {...props}>
+      <Icon name="Info" className="text-primary" />
     </Tooltip>
   );
 };

--- a/frontend/src/hooks/useNotifyToast.ts
+++ b/frontend/src/hooks/useNotifyToast.ts
@@ -4,6 +4,8 @@ interface ToastProps {
   title?: string;
   description?: string;
   icon?: string;
+  iconClassname?: string;
+  duration?: number;
 }
 
 export const useNotifyToast = () => {
@@ -13,33 +15,45 @@ export const useNotifyToast = () => {
     title = "Info",
     description,
     icon = "Info",
+    iconClassname,
+    duration = 5000,
   }: ToastProps) =>
     toast({
       title,
       description,
       icon,
+      iconClassname,
+      duration,
     });
 
   const successToast = ({
     title = "Success",
     description,
-    icon = "Success",
+    icon = "CheckCircle",
+    iconClassname = "text-green-400",
+    duration = 5000,
   }: ToastProps) =>
     toast({
       title,
       description,
       icon,
+      iconClassname,
+      duration,
     });
 
   const errorToast = ({
     title = "Error",
     description,
-    icon = "Error",
+    icon = "XCircle",
+    iconClassname = "text-destructive",
+    duration = 5000,
   }: ToastProps) =>
     toast({
       title,
       description,
       icon,
+      iconClassname,
+      duration,
     });
 
   return {

--- a/frontend/src/hooks/useRegisterForm.ts
+++ b/frontend/src/hooks/useRegisterForm.ts
@@ -13,7 +13,7 @@ const RegisterFormSchema = z.object({
 });
 
 export const useRegisterForm = () => {
-  const { infoToast } = useNotifyToast();
+  const { successToast, errorToast } = useNotifyToast();
 
   const form = useForm<z.infer<typeof RegisterFormSchema>>({
     resolver: zodResolver(RegisterFormSchema),
@@ -23,16 +23,22 @@ export const useRegisterForm = () => {
     },
   });
 
-  const handleSubmit = form.handleSubmit((values) => {
-    infoToast({
-      title: "Register Info",
-      description: `Registering user with email: ${values.email}`,
-      icon: "Success",
-    });
+  const submit = form.handleSubmit(async (values) => {
+    try {
+      successToast({
+        title: "Register Info",
+        description: `Registering user with email: ${values.email}`,
+      });
+    } catch (error) {
+      errorToast({
+        title: "Error in Registering",
+        description: JSON.stringify(form.formState.errors),
+      });
+    }
   });
 
   return {
     form,
-    handleSubmit,
+    submit,
   };
 };

--- a/frontend/src/hooks/useToast.ts
+++ b/frontend/src/hooks/useToast.ts
@@ -10,6 +10,7 @@ type ToasterToast = ToastProps & {
   title?: React.ReactNode;
   description?: React.ReactNode;
   icon?: string;
+  iconClassname?: string;
   action?: ToastActionElement;
 };
 

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -2,8 +2,12 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 import App from "./App.tsx";
 import "@/styles/index.css";
-import { withProviders } from "./utils/providers.ts";
+import { withProviders } from "@/utils/providers.ts";
+import { Toaster } from "@/components/Toast/Toaster.tsx";
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
-  <React.StrictMode>{withProviders(<App />)}</React.StrictMode>
+  <React.StrictMode>
+    {withProviders(<App />)}
+    <Toaster />
+  </React.StrictMode>
 );

--- a/frontend/src/pages/register/Register.tsx
+++ b/frontend/src/pages/register/Register.tsx
@@ -1,15 +1,57 @@
+import Button from "@/components/Button";
+import {
+  FormDescription,
+  FormItem,
+  FormLabel,
+  FormError,
+} from "@/components/Form";
+import Input from "@/components/Input";
 import { useRegisterForm } from "@/hooks/useRegisterForm";
 import { FormProvider } from "react-hook-form";
 
 const Register = () => {
-  const { form, handleSubmit } = useRegisterForm();
+  const { form, submit } = useRegisterForm();
+
   return (
     <div>
       <h1>Register</h1>
       <FormProvider {...form}>
-        <input type="text" name="email" />
-        <input type="password" name="password" />
-        <button onClick={handleSubmit}>Submit</button>
+        <FormItem name="email">
+          {({ field }) => (
+            <div className="flex flex-col items-start mb-5 space-y-2">
+              <FormLabel>Email</FormLabel>
+              <Input type="email" {...field} />
+              <FormDescription className="font-subjectivity">
+                Whereas recognition of the inherent dignity
+              </FormDescription>
+              <FormError />
+            </div>
+          )}
+        </FormItem>
+
+        <FormItem name="age">
+          {({ field }) => (
+            <div className="flex flex-col items-start mb-5 space-y-2">
+              <FormLabel optional>Age</FormLabel>
+              <Input type="text" placeholder="Enter your age" {...field} />
+              <FormError />
+            </div>
+          )}
+        </FormItem>
+
+        <FormItem name="password">
+          {({ field }) => (
+            <div className="flex flex-col items-start mb-5 space-y-2">
+              <FormLabel toolTipContent={"Enter atleast 8 characters"}>
+                Password
+              </FormLabel>
+              <Input type="password" {...field} />
+              <FormError />
+            </div>
+          )}
+        </FormItem>
+
+        <Button onClick={submit}>Submit</Button>
       </FormProvider>
     </div>
   );

--- a/frontend/src/utils/functions.ts
+++ b/frontend/src/utils/functions.ts
@@ -1,0 +1,72 @@
+export const arraysEqual = (arrayA: any[], arrayB: any[]) => {
+  return (
+    Array.isArray(arrayA) &&
+    Array.isArray(arrayB) &&
+    arrayA.length === arrayB.length &&
+    arrayA.every((value, index) => value === arrayB[index])
+  );
+};
+
+export const deepEqual = <T extends { [_: string]: any }>(a: T, b: T) => {
+  if (a === b) {
+    return true;
+  }
+
+  if (a instanceof Date && b instanceof Date) {
+    return a.getTime() === b.getTime();
+  }
+
+  if (!a || !b || (typeof a !== "object" && typeof b !== "object")) {
+    return a === b;
+  }
+
+  if (a === null || a === undefined || b === null || b === undefined) {
+    return false;
+  }
+
+  const aKeys = Object.keys(a);
+  const bKeys = Object.keys(b);
+
+  if (aKeys.length !== bKeys.length) {
+    return false;
+  }
+
+  aKeys.sort();
+  bKeys.sort();
+  for (let i = 0; i < aKeys.length; i++) {
+    if (aKeys[i] !== bKeys[i]) {
+      return false;
+    }
+
+    const key = aKeys[i];
+    if (!deepEqual(a[key], b[key])) {
+      return false;
+    }
+  }
+
+  return typeof a === typeof b;
+};
+
+export const isEmpty = (value: any) => {
+  if (value === null || value === undefined) {
+    return true;
+  }
+
+  if (typeof value === "string") {
+    return value.trim() === "";
+  }
+
+  if (Array.isArray(value)) {
+    return value.length === 0;
+  }
+
+  if (typeof value === "object") {
+    return Object.keys(value).length === 0;
+  }
+
+  if (typeof value === "function") {
+    return value.toString().trim() === "function() {}";
+  }
+
+  return false;
+};

--- a/frontend/src/utils/providers.ts
+++ b/frontend/src/utils/providers.ts
@@ -1,4 +1,3 @@
-import { Toast } from "@/components/Toast/Toast";
 import { ReactQueryProvider } from "@/context/QueryClientContext";
 import { RouteProvider } from "@/context/RouteContext";
 import { ThemeProvider } from "@/context/ThemeContext";
@@ -19,7 +18,7 @@ export const Compose = ({ components = [], children }: Props) => {
 
 export const withProviders = (children: React.ReactNode) => {
   const providers = Compose({
-    components: [ReactQueryProvider, ThemeProvider, RouteProvider, Toast],
+    components: [ReactQueryProvider, ThemeProvider, RouteProvider],
     children,
   });
 


### PR DESCRIPTION
In this PR, form and toast components are refactored accordingly to provide better developer experience in using these components.

- Form components were updated so that it will use the `<Controller/>` component from `react-hook-form` which allows developers to integrate non-traditional HTML elements.

- Small updates for toast components were also added to make toasts work and to provide flexibility in using this component.

- `useRegisterForm.ts` and `Register.tsx` will also serve as an example for Front-end developer users to how form components are used. These files will be updated soon in following PRs to match the needs of the project.

- Some utility functions were also added which will be used in this project.