### PR TITLE
Update icon library to phosphor

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@hookform/resolvers": "^3.3.1",
+        "@phosphor-icons/react": "^2.0.13",
         "@radix-ui/react-alert-dialog": "^1.0.5",
         "@radix-ui/react-aspect-ratio": "^1.0.3",
         "@radix-ui/react-avatar": "^1.0.4",
@@ -31,7 +32,6 @@
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.0.0",
         "date-fns": "^2.30.0",
-        "lucide-react": "^0.284.0",
         "react": "^18.2.0",
         "react-day-picker": "^8.9.0",
         "react-dom": "^18.2.0",
@@ -1019,6 +1019,18 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@phosphor-icons/react": {
+      "version": "2.0.13",
+      "resolved": "https://registry.npmjs.org/@phosphor-icons/react/-/react-2.0.13.tgz",
+      "integrity": "sha512-lRjFfCv4pU8vDnPgZ8/QFzYmAJS08Vx+J2/+Ldh217pXaxvaayBZMC/3EinuMwmMylc97+XYCMPdH+y10I+f0g==",
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8",
+        "react-dom": ">= 16.8"
       }
     },
     "node_modules/@radix-ui/number": {
@@ -3691,14 +3703,6 @@
       "dev": true,
       "dependencies": {
         "yallist": "^3.0.2"
-      }
-    },
-    "node_modules/lucide-react": {
-      "version": "0.284.0",
-      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.284.0.tgz",
-      "integrity": "sha512-dVSMHYAya/TeY3+vsk+VQJEKNQN2AhIo0+Dp09B2qpzvcBuu93H98YZykFcjIAfmanFiDd8nqfXFR38L757cyQ==",
-      "peerDependencies": {
-        "react": "^16.5.1 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/merge2": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@hookform/resolvers": "^3.3.1",
+    "@phosphor-icons/react": "^2.0.13",
     "@radix-ui/react-alert-dialog": "^1.0.5",
     "@radix-ui/react-aspect-ratio": "^1.0.3",
     "@radix-ui/react-avatar": "^1.0.4",
@@ -33,7 +34,6 @@
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.0.0",
     "date-fns": "^2.30.0",
-    "lucide-react": "^0.284.0",
     "react": "^18.2.0",
     "react-day-picker": "^8.9.0",
     "react-dom": "^18.2.0",

--- a/frontend/src/components/Alert.tsx
+++ b/frontend/src/components/Alert.tsx
@@ -60,7 +60,7 @@ interface AlertProps extends React.HTMLAttributes<HTMLDivElement> {
   variant?: "default" | "destructive";
   title?: string;
   description?: string;
-  icon?: React.ReactNode | string;
+  icon?: React.ReactNode;
   closable?: boolean;
 }
 

--- a/frontend/src/components/Button.tsx
+++ b/frontend/src/components/Button.tsx
@@ -71,14 +71,17 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
       if (size === "icon") {
         return (
           <>
-            <Icon name={loading ? "Loader2" : icon} className={iconClassName} />
+            <Icon
+              name={loading ? "CircleNotch" : icon}
+              className={iconClassName}
+            />
             {children}
           </>
         );
       }
       return (
         <>
-          {loading && <Icon name="Loader2" className={iconClassName} />}
+          {loading && <Icon name="CircleNotch" className={iconClassName} />}
           {children}
         </>
       );
@@ -101,4 +104,4 @@ Button.displayName = "Button";
 export default Button;
 export { buttonVariants };
 
-// Check Icon List here: https://lucide.dev/icons/
+// Check Icon List here: https://phosphoricons.com/

--- a/frontend/src/components/DatePicker.tsx
+++ b/frontend/src/components/DatePicker.tsx
@@ -1,10 +1,10 @@
 import * as React from "react";
 import { format } from "date-fns";
-import { Calendar as CalendarIcon } from "lucide-react";
 import Button from "@/components/Button";
 import Calendar from "@/components/Calendar";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/Popover";
 import { cn } from "@/utils/classes";
+import Icon from "@/components/Icon";
 
 export default function DatePickerDemo() {
   const [date, setDate] = React.useState<Date>();
@@ -19,7 +19,7 @@ export default function DatePickerDemo() {
             !date && "text-muted-foreground"
           )}
         >
-          <CalendarIcon className="mr-2 h-4 w-4" />
+          <Icon name="CalendarBlank" className="mr-2 h-4 w-4" />
           {date ? format(date, "PPP") : <span>Pick a date</span>}
         </Button>
       </PopoverTrigger>

--- a/frontend/src/components/Icon.tsx
+++ b/frontend/src/components/Icon.tsx
@@ -1,26 +1,45 @@
-import { icons, LucideProps } from "lucide-react";
+import { ComponentPropsWithRef } from "react";
+import * as phosphorIcons from "@phosphor-icons/react";
 
-export type IconName = keyof typeof icons;
-
-interface IconProps extends LucideProps {
+type IconWeight = "thin" | "light" | "regular" | "bold" | "fill" | "duotone";
+interface IconProps extends ComponentPropsWithRef<"svg"> {
   name: string;
+  alt?: string;
   color?: string;
-  size?: number;
-  className?: string | undefined;
+  size?: string | number;
+  weight?: IconWeight;
+  mirrored?: boolean;
+}
+type Icon = React.ForwardRefExoticComponent<IconProps>;
+
+interface IconMap {
+  [key: string]: any;
 }
 
-const Icon = ({ name, color, size, className, ...props }: IconProps) => {
-  if (!(name in icons)) {
+const Icon = ({
+  name,
+  color,
+  size,
+  weight,
+  mirrored,
+  className,
+  ...props
+}: IconProps) => {
+  const icons: IconMap = phosphorIcons as IconMap;
+
+  if (!name || !(name in icons)) {
     return;
   }
 
-  const LucideIcon = icons[name as IconName];
+  const PhosphorIcon = icons[name];
 
   return (
-    <LucideIcon
+    <PhosphorIcon
       name={name}
       color={color}
       size={size || 18}
+      weight={weight || "bold"}
+      mirrored={mirrored}
       className={className}
       {...props}
     />
@@ -29,4 +48,4 @@ const Icon = ({ name, color, size, className, ...props }: IconProps) => {
 
 export default Icon;
 
-// Check Icon List here: https://lucide.dev/icons/
+// Check Icon List here: https://phosphoricons.com/

--- a/frontend/src/components/Modal.tsx
+++ b/frontend/src/components/Modal.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { cn } from "@/utils/classes";
 import * as DialogPrimitive from "@radix-ui/react-dialog";
-import { Cross2Icon } from "@radix-ui/react-icons";
+import Icon from "@/components/Icon";
 
 const Dialog = DialogPrimitive.Root;
 
@@ -43,7 +43,7 @@ const DialogContent = React.forwardRef<
     >
       {children}
       <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
-        <Cross2Icon className="h-4 w-4" />
+        <Icon name="X" className="h-4 w-4" />
         <span className="sr-only">Close</span>
       </DialogPrimitive.Close>
     </DialogPrimitive.Content>

--- a/frontend/src/components/Sheet.tsx
+++ b/frontend/src/components/Sheet.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "@/utils/classes";
 import * as SheetPrimitive from "@radix-ui/react-dialog";
-import { Cross2Icon } from "@radix-ui/react-icons";
+import Icon from "@/components/Icon";
 
 const SheetContainer = SheetPrimitive.Root;
 
@@ -66,7 +66,7 @@ const SheetContent = React.forwardRef<
     >
       {children}
       <SheetPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-secondary">
-        <Cross2Icon className="h-4 w-4" />
+        <Icon name="X" className="h-4 w-4" />
         <span className="sr-only">Close</span>
       </SheetPrimitive.Close>
     </SheetPrimitive.Content>

--- a/frontend/src/components/Toast/Toast.tsx
+++ b/frontend/src/components/Toast/Toast.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "@/utils/classes";
-import { Cross2Icon } from "@radix-ui/react-icons";
+import Icon from "@/components/Icon";
 import * as ToastPrimitives from "@radix-ui/react-toast";
 
 const ToastProvider = ToastPrimitives.Provider;
@@ -80,7 +80,7 @@ const ToastClose = React.forwardRef<
     toast-close=""
     {...props}
   >
-    <Cross2Icon className="h-4 w-4" />
+    <Icon name="X" className="h-4 w-4" />
   </ToastPrimitives.Close>
 ));
 ToastClose.displayName = ToastPrimitives.Close.displayName;

--- a/frontend/src/components/Tooltip.tsx
+++ b/frontend/src/components/Tooltip.tsx
@@ -9,6 +9,29 @@ const TooltipContainer = TooltipPrimitive.Root;
 
 const TooltipTrigger = TooltipPrimitive.Trigger;
 
+const TooltipArrow = () => {
+  return (
+    <span
+      style={{
+        position: "absolute",
+        bottom: 1,
+        transform: "translateY(100%)",
+        left: 78.5,
+      }}
+    >
+      <svg
+        width="10"
+        height="5"
+        viewBox="0 0 30 10"
+        preserveAspectRatio="none"
+        style={{ display: "block" }}
+      >
+        <polygon points="0,0 30,0 15,10" />
+      </svg>
+    </span>
+  );
+};
+
 const TooltipContent = React.forwardRef<
   React.ElementRef<typeof TooltipPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Content>
@@ -54,7 +77,10 @@ const Tooltip = ({
         <TooltipTrigger asChild>
           <div>{children}</div>
         </TooltipTrigger>
-        <TooltipContent {...props}>{toolTipContent}</TooltipContent>
+        <TooltipContent {...props} sideOffset={8}>
+          <TooltipArrow />
+          {toolTipContent}
+        </TooltipContent>
       </TooltipContainer>
     </TooltipProvider>
   );


### PR DESCRIPTION
To match the icon libraries used by the designers, this PR updates the library used by FE from `radix icons` and `lucide icons` to `phosphor icons`.